### PR TITLE
Removed vacation (autoresponder) message length limitation

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ Originally written by Axel Sjøstedt.
   will contain the password to your Vexim database
 * Open config.inc.php
 * Add your Vexim database info
-* Check that the cryptscheme and vexim_vacation_maxlength settings
-  is the same as in your Vexim config 
+* Check that the cryptscheme setting is the same as in your Vexim config 
 * Check that the Vexim URL is correct if you want to provide a Vexim link
   to admin users

--- a/config.inc.php.dist
+++ b/config.inc.php.dist
@@ -15,12 +15,6 @@ $veximaccountadmin_config['db_dsn'] = 'mysql://USERNAME:PASSWORD@SERVER/DATABASE
 // 'des', 'md5', 'sha', 'sha512', 'bcrypt')
 $veximaccountadmin_config['vexim_cryptscheme'] = 'sha512';
 
-// Maxlength of autoresponder message, defaults to 255 characters. You probably want to
-// extend this limit. If so, you must change the vacation field in users table in
-// vexim database structure from VARCHAR(255) to TEXT. Also set $max_vacation_length
-// in vexim config/variables.php to get the same limit there.
-$veximaccountadmin_config['vexim_vacation_maxlength'] = 255;
-
 /*
 	Support for the Exim/Vexim customizations described on
 	http://axel.sjostedt.no/misc/vexim/
@@ -33,5 +27,3 @@ $veximaccountadmin_config['parsefolders_script_show_tip'] = true; // Show notice
 $veximaccountadmin_config['show_admin_link'] = true;
 // Vexim link URL, relative to Roundcube or external
 $veximaccountadmin_config['vexim_url'] = '../vexim/';
-
-?>

--- a/localization/en_US.inc
+++ b/localization/en_US.inc
@@ -62,10 +62,6 @@ $messages['headerblockdeleteall']  = 'Are you sure you want to delete all block 
 $messages['headerblockexists']  = 'This rule already exists';
 $messages['headerblockentervalue']  = 'You have to enter a value to the rule';
 
-$messages['autoresponderlong']  = 'Your autoresponder message exceeds the maximum length. Please make the message shorter and then click the save button again.';
-$messages['autoresponderlongnum']  = 'Number of characters in your message: ';
-$messages['autoresponderlongmax']  = 'Maximum number of characters: ';
-
 $labels['introtext']  = 'Here you can administrate your account settings. Remember that these settings are tied to the mail server itself, not only the webmail. Changes on this page will therefore also affect third-party mail clients you may use.';
 $labels['adminlinktext']  = 'You are registered as a domain administrator. On this page you can only edit your own settings. To get admin access for the whole domain (add/edit accounts, aliases, lists etc.) you will need to log in to %sVexim%s.';
 

--- a/localization/it_IT.inc
+++ b/localization/it_IT.inc
@@ -62,10 +62,6 @@ $messages['headerblockdeleteall']  = 'Cancellare tutte le regole?';
 $messages['headerblockexists']  = 'Regola già presente';
 $messages['headerblockentervalue']  = 'Valore mancante';
 
-$messages['autoresponderlong']  = 'Il messaggio di risposta automatica è troppo lungo. Accorciarlo e salvare di nuovo.';
-$messages['autoresponderlongnum']  = 'Numero di caratteri nel messaggio: ';
-$messages['autoresponderlongmax']  = 'Numero massimo di caratteri: ';
-
 $labels['introtext']  = 'Qui si amministrano le impostazioni del suo account. Si ricordi che queste impostazioni sono legate alla sua casella in generale, e non soltanto alla webmail, pertanto ogni cambiamento in questa pagina riguarda anche eventuali altri client.';
 $labels['adminlinktext']  = 'Il suo account è amministrativo, ma in questa pagina è possibile modificare solo le sue impostazioni personali. Per accedere all\'amministrazione del dominio (aggiunta modifica account, alias, liste...) si autentichi su %sVexim%s.';
 

--- a/localization/nb_NO.inc
+++ b/localization/nb_NO.inc
@@ -62,10 +62,6 @@ $messages['headerblockdeleteall']  = 'Er du sikker på at du vil slette alle reg
 $messages['headerblockexists']  = 'Denne regelen finnes allerede';
 $messages['headerblockentervalue']  = 'Du må skrive inn en verdi til regelen';
 
-$messages['autoresponderlong']  = 'Din autosvarmelding overstiger maksimal tillatt lengde. Vennligst forkort teksten og trykk deretter lagre på nytt.';
-$messages['autoresponderlongnum']  = 'Antall tegn i din melding: ';
-$messages['autoresponderlongmax']  = 'Maksimalt antall tegn: ';
-
 $labels['introtext']  = 'Her kan du administrere dine kontoinnstillinger. Husk at disse innstillingene er knyttet til mailserveren, ikke bare webmailen. Endringer du gjør på denne siden vil derfor også påvirke andre mailprogrammer du bruker for denne adressen.';
 $labels['adminlinktext']  = 'Du er oppført som domeneadministrator. Fra denne siden kan du kun endre dine egne kontoinnstillinger, du kan ikke legge til/endre konti, videresendinger, lister osv. For å få slik administratortilgang må du logge på med %sVexim%s.';
 

--- a/veximaccountadmin.js
+++ b/veximaccountadmin.js
@@ -33,9 +33,6 @@ if (window.rcmail) {
 	} else if (input_newpasswd.value != input_confpasswd.value && input_newpasswd.value!='' && input_confpasswd.value!='') {
 		alert(rcmail.gettext('passwordinconsistency', 'veximaccountadmin'));
 		input_newpasswd.focus();	
-	} else if ( input_vacation.value.length > rcmail.env.vacation_maxlength) {
-		alert(rcmail.gettext('autoresponderlong', 'veximaccountadmin') + '\n\n' + rcmail.gettext('autoresponderlongnum', 'veximaccountadmin') + input_vacation.value.length + '\n' +rcmail.gettext('autoresponderlongmax', 'veximaccountadmin') + rcmail.env.vacation_maxlength);
-		input_vacation.focus();	
 	} else {
           rcmail.gui_objects.veximform.submit();
     }

--- a/veximaccountadmin.php
+++ b/veximaccountadmin.php
@@ -562,6 +562,8 @@ class veximaccountadmin extends rcube_plugin
 		   return $err;
 		}
 		$ret = $this->db->fetch_assoc($res);
+
+		$ret['vacation'] = quoted_printable_decode($ret['vacation']);
 	
 		return $ret;  
 	}
@@ -593,6 +595,8 @@ class veximaccountadmin extends rcube_plugin
 		$settings = $this->_get_configuration();
 		$user_id			= $settings['user_id'];
 		$domain_id			= $settings['domain_id'];
+
+		$vacation = quoted_printable_encode($vacation);
 	
 			foreach ($acts as $idx => $act){
 				if ($act == "DELETE") {

--- a/veximaccountadmin.php
+++ b/veximaccountadmin.php
@@ -124,12 +124,6 @@ class veximaccountadmin extends rcube_plugin
 	
 		$vacation = get_input_value('vacation', RCUBE_INPUT_POST);
 		
-		// In case someone bypass the javascript maxlength, we make vacation message
-		// shorter if above treshold
-		if (strlen($vacation) > $this->config['vexim_vacation_maxlength']) {
-			$vacation = substr($vacation, 0, $this->config['vexim_vacation_maxlength']);
-		}
-		
 		$on_forward = get_input_value('on_forward', RCUBE_INPUT_POST);
 		if(!$on_forward)
 			$on_forward = 0;
@@ -204,9 +198,6 @@ class veximaccountadmin extends rcube_plugin
 		$default_maxmsgsize	= $domain_settings['maxmsgsize'];
 		$active_domain		= $domain_settings['domain'];
 		
-		$rcmail->output->set_env('vacation_maxlength', $this->config['vexim_vacation_maxlength']);
-		
-	
 		$out .= '<p class="introtext">' . $this->gettext('introtext') . '</p>' . "\n";
 
 


### PR DESCRIPTION
We now store the vacation message in a TEXT field, so there is no need to limit its length in the UI anymore.