### PR TITLE
Folder name must be veximaccountadmin

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ https://github.com/vexim/Roundcube-Plugin-VeximAccountAdmin/
 ## Install ##
 
 * Place plugin folder into plugins directory of Roundcube
-* Set folder to `veximaccountadmin`
+* Rename the folder to `veximaccountadmin`
 * Enable the plugin by adding it to the Roundcube configuration file 
   Example: 
   

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ https://github.com/vexim/Roundcube-Plugin-VeximAccountAdmin/
 ## Install ##
 
 * Place plugin folder into plugins directory of Roundcube
+* Set folder to `veximaccountadmin`
 * Enable the plugin by adding it to the Roundcube configuration file 
   Example: 
   


### PR DESCRIPTION
When you clone the git-repository, the default folder name is `Roundcube-Plugin-VeximAccountAdmin` but it must be `veximaccountadmin` that it fits its plugin-name.